### PR TITLE
fix for com.netflix.spectator.api.Registry bean creation issue

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatAuthenticationConfig.java
@@ -21,6 +21,8 @@ import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jakewharton.retrofit.Ok3Client;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.config.DefaultServiceEndpoint;
 import com.netflix.spinnaker.config.ErrorConfiguration;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
@@ -61,6 +63,11 @@ public class FiatAuthenticationConfig {
   @Autowired(required = false)
   @Setter
   private RestAdapter.LogLevel retrofitLogLevel = RestAdapter.LogLevel.BASIC;
+
+  @Bean
+  Registry getRegistry() {
+    return new DefaultRegistry();
+  }
 
   @Bean
   @ConditionalOnMissingBean(FiatService.class) // Allows for override

--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/FiatPermissionEvaluator.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.fiat.shared;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.fiat.model.Authorization;
@@ -134,7 +133,7 @@ public class FiatPermissionEvaluator implements PermissionEvaluator {
       FiatClientConfigurationProperties configProps,
       FiatStatus fiatStatus,
       RetryHandler retryHandler) {
-    this.registry = new DefaultRegistry();
+    this.registry = registry;
     this.fiatService = fiatService;
     this.fiatStatus = fiatStatus;
     this.retryHandler = retryHandler;


### PR DESCRIPTION
fix for issue in front50 startup:
'Field registry in com.netflix.spinnaker.front50.config.Front50WebConfig required a bean of type 'com.netflix.spectator.api.Registry' that could not be found.'

