### PR TITLE
bugfix for OP-20338 NoSuchBeanDefinitionException: No qualifying bean of type com.netflix.spectator.api.Registry available issue

### DIFF
--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.fiat.config;
 
 import com.google.common.collect.ImmutableList;
-import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.config.PluginsAutoConfiguration;
 import com.netflix.spinnaker.fiat.model.Authorization;
@@ -19,7 +18,6 @@ import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter;
-import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener;
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -27,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -48,22 +47,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @EnableConfigurationProperties(FiatServerConfigurationProperties.class)
 public class FiatConfig implements WebMvcConfigurer {
 
-  @Bean
-  Registry getRegistry() {
-    return new DefaultRegistry();
-  }
-
-  @Bean
-  DiscoveryStatusListener getDiscoveryStatusListener() {
-    return new DiscoveryStatusListener();
-  }
+  @Autowired private Registry registry;
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     var pathVarsToTag = ImmutableList.of("accountName", "applicationName", "resourceName");
     List<String> exclude = ImmutableList.of("BasicErrorController");
     MetricsInterceptor interceptor =
-        new MetricsInterceptor(getRegistry(), "controller.invocations", pathVarsToTag, exclude);
+        new MetricsInterceptor(this.registry, "controller.invocations", pathVarsToTag, exclude);
     registry.addInterceptor(interceptor);
   }
 


### PR DESCRIPTION
Fixed as suggested in:
https://github.com/spring-projects/spring-boot/issues/33413
The 3.0 [release notes link to the dedicated migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes#upgrading-from-spring-boot-27), which is where most of the information needed when migrating from 2.7 to 3.0 is located.
and
https://medium.com/spring-boot/auto-configure-your-common-module-in-the-spring-boot-way-32acd3976a70