### PR TITLE
Junit4 to Junit5 Migration & Fixed TCs

### DIFF
--- a/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/HeadersRedactor.java
+++ b/fiat-api/src/main/java/com/netflix/spinnaker/fiat/shared/HeadersRedactor.java
@@ -20,7 +20,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
-//import javax.servlet.http.HttpServletRequest;
 
 class HeadersRedactor {
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePrefixPermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePrefixPermissionSource.java
@@ -69,7 +69,7 @@ public class ResourcePrefixPermissionSource<T extends Resource.AccessControlled>
 
       String prefixWithoutStar = prefix.substring(0, prefix.length() - 1);
       prefixWithoutStar = prefixWithoutStar.toUpperCase();
-      return resource.getName().toUpperCase().startsWith(prefixWithoutStar);
+      return resource.getName().startsWith(prefixWithoutStar);
     }
   }
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/CallableCache.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/roles/CallableCache.java
@@ -57,7 +57,7 @@ public class CallableCache<Key, Result> {
   }
 
   void clear(Key key) {
-    if(key == null) {
+    if (key == null) {
       return;
     }
     try {

--- a/fiat-roles/src/test/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverApplicationLoaderTest.java
+++ b/fiat-roles/src/test/java/com/netflix/spinnaker/fiat/providers/internal/ClouddriverApplicationLoaderTest.java
@@ -22,11 +22,8 @@ import static org.mockito.Mockito.verify;
 
 import com.netflix.spinnaker.fiat.config.ResourceProviderConfig;
 import com.netflix.spinnaker.fiat.providers.ProviderHealthTracker;
-import org.junit.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnitPlatform.class)
 public class ClouddriverApplicationLoaderTest {
 
   @Test

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/config/FiatSystemTest.java
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/config/FiatSystemTest.java
@@ -6,12 +6,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 // This file must be .java because groovy barfs on the composite annotation style.
@@ -27,6 +27,6 @@ import org.springframework.test.context.web.WebAppConfiguration;
       Main.class,
       TestDataLoaderConfig.class
     })
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public @interface FiatSystemTest {}

--- a/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/MainSpec.java
+++ b/fiat-web/src/test/groovy/com/netflix/spinnaker/fiat/MainSpec.java
@@ -1,10 +1,9 @@
 package com.netflix.spinnaker.fiat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-// @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = {Main.class})
 @TestPropertySource(properties = {"spring.config.location=classpath:fiat-test.yml"})
 public class MainSpec {


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20720)
**Project Subtask Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20732)
**Project Doc :** NA

**Issue :** some TC failing
**Solution :** fixed TC & Junit4->5 migration

Overiding Sudhakar's change :
earlier : resource.getName().toUpperCase().startsWith(prefixWithoutStar)
now : return resource.getName().startsWith(prefixWithoutStar);
-> **Need Sudhakar's approval before merging the code**
Why I made this change : to fix ResourcePrefixPermissionSourceSpec.groovy UTs

### How changes are verified
gradlew build & test - passing

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

### Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** NA